### PR TITLE
fix: stalemate check and castling calculation fix

### DIFF
--- a/src/client/match-logic/base-match.ts
+++ b/src/client/match-logic/base-match.ts
@@ -61,7 +61,7 @@ export class BaseMatch {
   }
 
   isGameOver() {
-    return this.game.getGameState().status === GAMESTATUS.CHECKMATE;
+    return this.game.getGameState().status !== GAMESTATUS.INPROGRESS;
   }
 
   getWinner() {

--- a/src/client/match-logic/controller.ts
+++ b/src/client/match-logic/controller.ts
@@ -131,7 +131,8 @@ export class Controller {
     this.displayLastTurn();
     const isGameOver = this.match.isGameOver();
     if (isGameOver) {
-      this.events.setMessage(this.createMatchEndPrompt());
+      const status = this.match.getGame().getGameState().status;
+      this.events.setMessage(this.createMatchEndPrompt(status));
     } else {
       this.rotateCamera();
     }
@@ -182,10 +183,20 @@ export class Controller {
     });
   }
 
-  createMatchEndPrompt() {
-    const winningTeam = this.match.getWinner();
+  createMatchEndPrompt(status: GAMESTATUS) {
+    const text = (() => {
+      const winningTeam = this.match.getWinner();
+      switch (status) {
+        case GAMESTATUS.CHECKMATE:
+          return `Checkmate! ${winningTeam} team has won, would you like to play another game?`;
+        case GAMESTATUS.STALEMATE:
+          return "Game has ended in a stalemate, would you like to play another game?";
+        default:
+          return "Game Over! Would you like to play another game";
+      }
+    })();
     return {
-      text: `${winningTeam} team has won!, Would you like to play another game?`,
+      text,
       onConfirm: () => {
         this.requestMatchReset();
         this.events.setMessage(null);

--- a/src/client/scenes/scene-helpers.ts
+++ b/src/client/scenes/scene-helpers.ts
@@ -7,6 +7,7 @@ import { pointIndexMap, pointPositionMap } from "../data/point-map-data";
 import { GameScene } from "./scene-manager";
 
 const Y_ABOVE_FLOOR = 0.51;
+const Y_ABOVE_FLOOR_EXTENDED = 0.55;
 
 export const showMoves = ({
   point,
@@ -109,7 +110,12 @@ export const createMovementDisc = ({
     radius: 1.1,
   });
   disc.isPickable = false;
-  disc.setPositionWithLocalVector(new Vector3(x, Y_ABOVE_FLOOR, z));
+  //Needed so previous turn marker wont be above display moves
+  if (type === "previousTurn") {
+    disc.setPositionWithLocalVector(new Vector3(x, Y_ABOVE_FLOOR, z));
+  } else {
+    disc.setPositionWithLocalVector(new Vector3(x, Y_ABOVE_FLOOR_EXTENDED, z));
+  }
   disc.rotation = new Vector3(Math.PI / 2, 0, 0);
   const material = findMaterial(type, gameScene.scene);
   if (material) {


### PR DESCRIPTION
This pull request includes the following changes:

- Fixes castling calculation to only happen on players turn's getMoves
- Added a stalemate check feature.

The stalemate check feature ensures that the game can detect when a stalemate occurs, ending the game in a draw. The y position above the floor in the scene helpers file has been fixed to prevent the previous turn marker from being displayed above the move markers.