### PR TITLE
build: esbuild cli api into a config file for readability/maintainability

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,0 +1,67 @@
+import { build, context } from "esbuild";
+import fs from "node:fs/promises";
+
+// "esbuild src/client/index.tsx --bundle --outdir=dist/client --target=es2022  --format=esm --sourcemap",
+//     "build:server": "esbuild src/server/index.ts --bundle --outdir=dist/server --packages=external --platform=node --sourcemap --format=esm",
+
+const isWatch = process.argv.includes("--watch") || process.argv.includes("-w");
+const outPath = new URL("dist/", import.meta.url);
+const clientPath = new URL("dist/client", import.meta.url);
+const publicPath = new URL("public/", import.meta.url);
+
+/** @type {import('esbuild').BuildOptions} */
+const commonBuildOptions = {
+  logLevel: "info",
+  color: true,
+  outdir: "dist",
+  legalComments: "none",
+  bundle: true,
+  target: "es2022",
+  loader: {
+    ".png": "file",
+    ".jpeg": "file",
+    ".jpg": "file",
+    ".svg": "file",
+    ".mp3": "file",
+    ".gltf": "file",
+    ".webp": "file",
+  },
+  minify: !isWatch,
+  sourcemap: isWatch,
+  define: {
+    "process.env.NODE_ENV": isWatch ? '"development"' : '"production"',
+  },
+};
+
+/** @type {import('esbuild').BuildOptions} */
+const nodeEsmBundles = {
+  platform: "node",
+  ...commonBuildOptions,
+  format: "esm",
+  entryPoints: ["src/server/index.ts"],
+  outdir: "dist/server",
+  packages: "external",
+};
+
+/** @type {import('esbuild').BuildOptions} */
+const browserEsmBundle = {
+  ...commonBuildOptions,
+  format: "esm",
+  entryPoints: ["src/client/index.tsx"],
+  outdir: "dist/client",
+};
+
+await fs.rm(outPath, { recursive: true, force: true });
+await fs.mkdir(outPath, { recursive: true });
+await fs.cp(publicPath, clientPath, { recursive: true });
+
+const bundles = [nodeEsmBundles, browserEsmBundle];
+
+if (isWatch) {
+  const buildContexts = await Promise.all(
+    bundles.map((bundle) => context(bundle))
+  );
+  await Promise.all(buildContexts.map((context) => context.watch()));
+} else {
+  await Promise.all(bundles.map((bundle) => build(bundle)));
+}

--- a/package.json
+++ b/package.json
@@ -6,21 +6,12 @@
   "type": "module",
   "scripts": {
     "clean": "node -e \"fs.rmSync('dist', {recursive: true, force: true})\"",
-    "start": "concurrently --names client,server,nodemon -c auto --kill-others \"npm:watch:client\" \"npm:watch:server\" \"npm:nodemon:server\"",
+    "start": "concurrently --names esbuild,nodemon -c auto \"npm:build\" \"npm:nodemon:server\"",
     "typecheck": "tsc --noEmit",
     "test": "glob -c \"node --import tsx --test\" \"src/tests/**/*.test.ts\"",
-    "prebuild": "npm run clean",
-    "prestart": "npm run build",
-    "copy:public": "node -e \"fs.cpSync('public', 'dist/client', {recursive: true})\"",
-    "build": "npm run copy:public && npm run build:client && npm run build:server",
-    "build:client": "esbuild src/client/index.tsx --bundle --outdir=dist/client --target=es2022 --loader:.svg=file --loader:.mp3=file --loader:.gltf=file --loader:.png=file --loader:.webp=file --format=esm --sourcemap",
-    "build:server": "esbuild src/server/index.ts --bundle --outdir=dist/server --packages=external --platform=node --sourcemap --format=esm",
-    "watch:client": "npm run build:client -- --watch",
-    "watch:server": "npm run build:server -- --watch",
-    "nodemon:server": "nodemon dist/server/index.js",
-    "build:prod": "npm run copy:public && npm run build:prod:client && npm run build:prod:server",
-    "build:prod:client": "esbuild src/client/index.tsx --bundle --outdir=dist/client --target=es2022 --loader:.svg=file --loader:.mp3=file --loader:.gltf=file --loader:.png=file --loader:.webp=file --format=esm --minify",
-    "build:prod:server": "esbuild src/server/index.ts --bundle --outdir=dist/server --packages=external --platform=node  --format=esm --minify"
+    "build": "node esbuild.config.js -- -w",
+    "build:prod": "node esbuild.config.js",
+    "nodemon:server": "nodemon dist/server/index.js"
   },
   "browserslist": [
     "last 1 Chrome version"


### PR DESCRIPTION
This pull request refactors the build process by introducing an esbuild configuration file. The `esbuild.config.js` file contains the build options for both the server and client bundles. The previous build scripts in the `package.json` file have been replaced with a single `build` script that runs the `esbuild.config.js` file. This change improves readability and maintainability of the build process.

As a result, the package.json scripts were cleaned up a bit as well as the "pre" scripts weren't needed as they occur within the esbuild config file.