### PR TITLE
fix(overlay): text selection, ready checks, and player turn indicator

### DIFF
--- a/src/client/components/game-overlay/footer-game-overlay.tsx.tsx
+++ b/src/client/components/game-overlay/footer-game-overlay.tsx.tsx
@@ -13,13 +13,15 @@ export const FooterGameOverlay: React.FC<{
         <div className="inline-block w-1/2" key={index}>
           <div className="flex flex-col items-center bg-slate-700 rounded-lg p-2 m-2 relative min-w-1/3 overflow-hidden whitespace-nowrap transition-all duration-500 ease-in-out transform hover:scale-105">
             <div
-              className={`absolute top-2 ${
-                index % 2 === 0 ? "left-2" : "right-2"
+              className={`absolute top-1 transition-all duration-500 ease-in-out ${
+                index % 2 === 0 ? "left-1" : "right-1"
               } ${
-                player.team === TEAM.WHITE ? "bg-white" : "bg-black"
-              } rounded-full w-4 h-4 ${
-                info?.currentTeam === player.team ? "animate-pulse" : ""
-              }`}
+                info?.currentTeam === player.team
+                  ? "animate-pulse bg-red-500"
+                  : player.team === TEAM.WHITE
+                  ? "bg-white"
+                  : "bg-black"
+              } rounded-full w-4 h-4`}
             ></div>
             <p className="font-bold text-lg whitespace-nowrap overflow-hidden text-ellipsis w-3/4 max-w-3/4">
               {player.name}

--- a/src/client/components/game-overlay/game-overlay.tsx
+++ b/src/client/components/game-overlay/game-overlay.tsx
@@ -15,7 +15,7 @@ export const GameOverlay: React.FC<{
 }> = ({ headerItems, lobby, info }) => {
   return (
     <div>
-      <div className="z-10 absolute top-0 w-full bg-transparent text-center">
+      <div className="z-10 absolute select-none top-0 w-full bg-transparent text-center">
         <div className="max-w-[600px] text-center t m-auto">
           {headerItems.map((item, idx) => (
             <HeaderGameOverlay item={item} key={idx} />

--- a/src/client/components/lobby/player-card.tsx
+++ b/src/client/components/lobby/player-card.tsx
@@ -7,7 +7,8 @@ import { XIcon } from "../svg/x-icon";
 const PlayerCard: React.FC<{
   player: Player | undefined;
   children?: React.ReactNode;
-}> = ({ player, children }) => {
+  hideReady?: boolean;
+}> = ({ player, hideReady = false, children }) => {
   return (
     <div className="h-full relative w-1/2 grow p-1 bg-slate-600 rounded-lg border-2 border-black">
       <div className="h-12 bg-slate-400 rounded p-1 text-nowrap">
@@ -33,13 +34,15 @@ const PlayerCard: React.FC<{
           >
             {player.id ? player.name : "Invite Code"}
           </p>
-          <p className={`float-right inline-block text-lg mt-0.5`}>
-            {player?.ready ? (
-              <Checkmark size={25} className="p-0.5" />
-            ) : (
-              <XIcon size={25} />
-            )}
-          </p>
+          {!hideReady && (
+            <p className={`float-right inline-block text-lg mt-0.5`}>
+              {player?.ready ? (
+                <Checkmark size={25} className="p-0.5" />
+              ) : (
+                <XIcon size={25} />
+              )}
+            </p>
+          )}
         </div>
       ) : (
         <>

--- a/src/client/routes/offline-lobby.tsx
+++ b/src/client/routes/offline-lobby.tsx
@@ -94,7 +94,7 @@ export const OfflineLobby: React.FC<{
         {lobby.players.map((player, i) => {
           return (
             <React.Fragment key={i}>
-              <PlayerCard player={player}>
+              <PlayerCard player={player} hideReady={true}>
                 {player.type === "Computer" ? (
                   <div className="overflow-x-scroll whitespace-nowrap mt-1 p-1 rounded bg-slate-700 text-slate-200">
                     <span className="text-sm">Depth</span>


### PR DESCRIPTION
Implement changes to prevent text selection on the overlay, hide ready checks in the offline lobby, and enhance the player turn indicator light for better visibility.

Fixes #238