### PR TITLE
feat: support offline mode and improve caching logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-game",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-game",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@babylonjs/core": "^7.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-game",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "3D Chess Game",
   "main": "dist/index.js",
   "type": "module",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,23 @@
 const expectedCaches = [`3d-chess-v1.3.11`];
 
+const allowedExtensions = [
+  "js",
+  "css",
+  "gltf",
+  "svg",
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "ico",
+  "mp3",
+];
+
+function endsWithAny(str, extensions) {
+  const regex = new RegExp(`\\.(${extensions.join("|")})$`);
+  return regex.test(str);
+}
+
 // Use the install event to pre-cache all initial resources.
 self.addEventListener("install", (event) => {
   event.waitUntil(
@@ -25,6 +43,7 @@ self.addEventListener("install", (event) => {
         "/click-2VCHPPVR.mp3",
         "/crumble-BBBHSYQE.mp3",
         "/tube-ZB5725HQ.png",
+        "/clock-CWUFNU4D.svg",
       ]);
     })()
   );
@@ -57,7 +76,10 @@ self.addEventListener("fetch", (event) => {
     (async () => {
       const isGetRequest = event.request.method === "GET";
       const isRootRequest = event.request.url === self.location.origin + "/";
-      if (isGetRequest && (event.request.url.includes(".") || isRootRequest)) {
+      if (
+        isGetRequest &&
+        (endsWithAny(event.request.url, allowedExtensions) || isRootRequest)
+      ) {
         const cache = await caches.open(expectedCaches.at(-1));
         // Get the resource from the cache.
         const cachedResponse = await cache.match(event.request);


### PR DESCRIPTION
Enhance the service worker to support offline mode by try/catch the sw own request.

Additionally adds that if the request is for a static asset then it will return the cached response initially. No reason to check server as these assets already get a key in the name from esbuild.

Also caching only resources with allowed extensions and updating the version to 1.4.2.