### PR TITLE
fix: timer handling and bind switchPlayer method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chess-game",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-game",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "license": "MIT",
       "dependencies": {
         "@babylonjs/core": "^7.42.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-game",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "3D Chess Game",
   "main": "dist/index.js",
   "type": "module",

--- a/src/client/game-logic/game.ts
+++ b/src/client/game-logic/game.ts
@@ -63,12 +63,14 @@ class Game {
     grid = this.current.grid,
     simulate,
     onPromotion,
+    onSuccess,
   }: {
     from: Point;
     to: Point;
     grid?: Grid;
     simulate?: boolean;
     onPromotion?: (resolve: (piece: PIECE) => void) => void;
+    onSuccess?: (move: Move) => void;
   }) {
     if (this.current.status !== GAMESTATUS.INPROGRESS) return;
     const move = this.findMove({ grid, from, to });
@@ -101,6 +103,7 @@ class Game {
     this.annotate(resolved);
     if (!simulate) {
       this.nextTurn();
+      onSuccess?.(move);
     }
     return resolved;
   }

--- a/src/client/match-logic/controller.ts
+++ b/src/client/match-logic/controller.ts
@@ -159,6 +159,7 @@ export class Controller {
     if (isGameOver) {
       const status = this.match!.getGame().getState().status;
       this.events.setMessage(this.createMatchEndPrompt(status));
+      this.match?.timer?.stop();
     } else {
       this.rotateCamera();
     }

--- a/src/client/match-logic/offline-match.ts
+++ b/src/client/match-logic/offline-match.ts
@@ -48,8 +48,8 @@ export class OfflineMatch extends BaseMatch implements MatchLogic {
       from: from,
       to: to,
       onPromotion: this.onPromotion,
+      onSuccess: this.timer?.switchPlayer.bind(this.timer),
     });
-    this.timer?.switchPlayer();
     return {
       turn,
       callback: () => {

--- a/src/client/match-logic/online-match.ts
+++ b/src/client/match-logic/online-match.ts
@@ -37,6 +37,7 @@ export class OnlineMatch extends BaseMatch implements MatchLogic {
       from: from,
       to: to,
       onPromotion: this.onPromotion,
+      onSuccess: this.timer?.switchPlayer.bind(this.timer),
     });
     return {
       turn,


### PR DESCRIPTION
Bind the `switchPlayer` method to the timer and ensure the timer stops when a match ends. Update the version to 1.4.7.